### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,10 @@ RUN pip2.7 install Pillow
 WORKDIR /opt
 
 # Get loris and unzip. 
-RUN wget --no-check-certificate https://github.com/loris-imageserver/loris/archive/2.0.1.zip \
-	&& unzip 2.0.1.zip \
-	&& mv loris-2.0.1/ loris/ \
-	&& rm 2.0.1.zip
+RUN wget --no-check-certificate https://github.com/loris-imageserver/loris/archive/v2.1.0-final.zip \
+	&& unzip loris-2.1.0-final.zip \
+	&& mv loris-2.1.0-final/ loris/ \
+	&& rm loris-2.1.0-final.zip
 
 RUN useradd -d /var/www/loris -s /sbin/false loris
 


### PR DESCRIPTION
use Loris v2.1.0

fixes [an issue](https://github.com/loris-imageserver/loris/issues/290) related to files mounted from an OSX host causing 500 errors.